### PR TITLE
fix(results-processor): Do not process as manual list if articles array present but empty

### DIFF
--- a/lib/results-processor.js
+++ b/lib/results-processor.js
@@ -17,7 +17,7 @@ function createProcessor(crudService, options) {
    */
   function processResults(results, articles, callback) {
 
-    if (!articles || articles.length === 0) {
+    if (!articles || !articles.length) {
       callback(null, results)
     } else {
 

--- a/lib/results-processor.js
+++ b/lib/results-processor.js
@@ -17,7 +17,7 @@ function createProcessor(crudService, options) {
    */
   function processResults(results, articles, callback) {
 
-    if (!articles) {
+    if (!articles || articles.length === 0) {
       callback(null, results)
     } else {
 

--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "type": "git",
     "url": "git@github.com:clocklimited/region-list-aggregator"
   },
-  "publishConfig": {
-    "registry": "http://npm.clockte.ch"
-  },
   "main": "./list-aggregator.js",
   "scripts": {
     "lint": "./node_modules/.bin/jshint . --reporter=./node_modules/jshint-full-path/index.js",


### PR DESCRIPTION
Issue:

Once a list exists as a manual list it gains the `articles` array.
When it changes to an automatic list this array is emptied but cannot be deleted (because save does an update, with the field omitted, does not result it in being deleted).
This results in this aggregator processing auto lists as if they are empty manual ones.

Manual lists already have schema validation in place to prevent empty articles arrays.